### PR TITLE
Fix/wrong id generation

### DIFF
--- a/src/Papst.EventStore.Abstractions/DependencyInjectionEventApplier.cs
+++ b/src/Papst.EventStore.Abstractions/DependencyInjectionEventApplier.cs
@@ -41,6 +41,8 @@ namespace Papst.EventStore.Abstractions
             // the entity type as first type argument to the IEventApplier<,>
             Type entityType = target.GetType();
 
+            bool isFirstEvent = true;
+
             foreach (var evt in stream.Stream)
             {
                 try
@@ -55,12 +57,13 @@ namespace Papst.EventStore.Abstractions
                         _logger.LogInformation("Entity has been deleted at {Version}", previousVersion);
                         break;
                     }
-                    else if (target.Version == previousVersion)
+                    else if (target.Version == previousVersion && !isFirstEvent)
                     {
-                        // increment the version only if it is not done by the event Applier
-                        // note this will affect the version on creation: First Version will be incremented
+                        // --> Version is incremented when not done by custom logic and its not the first event
                         target.Version++;
                     }
+
+                    isFirstEvent = false;
                 }
                 catch (InvalidOperationException exc)
                 {

--- a/src/Papst.EventStore.Abstractions/DependencyInjectionEventApplier.cs
+++ b/src/Papst.EventStore.Abstractions/DependencyInjectionEventApplier.cs
@@ -57,9 +57,10 @@ namespace Papst.EventStore.Abstractions
                         _logger.LogInformation("Entity has been deleted at {Version}", previousVersion);
                         break;
                     }
-                    else if (target.Version == previousVersion && !isFirstEvent)
+                    else if (target.Version == previousVersion && (previousVersion > _options.Value.StartVersion || !isFirstEvent))
                     {
                         // --> Version is incremented when not done by custom logic and its not the first event
+                        // --> When the Version is already greater StartVersion, it is rebuild from a SnapShot -> increment the version then
                         target.Version++;
                     }
 

--- a/src/Papst.EventStore.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Papst.EventStore.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Data.Common;
 using System.Linq;
 using System.Reflection;
 
@@ -22,14 +23,16 @@ namespace Papst.EventStore.Abstractions.Extensions
             Type interfaceType = typeof(IEventAggregator<,>);
 
             // scan the assemblies for types that implement IEventApplier<>
-            var types = assemblies
+            var allTypes = assemblies
                 .SelectMany(a => a.DefinedTypes)
                 .Distinct()
                 .Where(t =>
                     t.IsClass &&
-                    !t.IsAbstract &&
-                    t.ImplementedInterfaces.Any(itrf => itrf.IsGenericType && itrf.GetGenericTypeDefinition() == interfaceType)
-                );
+                    !t.IsAbstract
+                )
+                .ToList();
+            var types = allTypes
+                .Where(t => t.ImplementedInterfaces.Any(itrf => itrf.IsGenericType && itrf.GetGenericTypeDefinition() == interfaceType));
 
             foreach (TypeInfo type in types)
             {


### PR DESCRIPTION
Prevents increment on first event. This prevents having a different version tag on the Entity than in the event